### PR TITLE
EC does not choose supported collateral types

### DIFF
--- a/lectureNine/lectureNine.md
+++ b/lectureNine/lectureNine.md
@@ -195,8 +195,8 @@ if one trade fails, others can keep functioning as expected.
 ### VaultFactory
 `VaultFactory` is another alternative for purchasing IST. Since IST is a fully collateralized stablecoin, users can only
 exchange IST against some collateral. `VaultFactory` is similar to `PSM` in this sense. The difference lies within 
-the type of collateral accepted. `VaultFactory` can accept any type of ERTP asset as collateral as long as the 
-`Economic Commitee` approves it whereas `PSM` only accepts stablecoins. This significant difference causes one other
+the type of collateral accepted. `VaultFactory` can accept any type of ERTP asset as collateral as long as 
+BLD staker governance approves it whereas `PSM` only accepts stablecoins. This significant difference causes one other
 major difference and that is `over-collateralization`. `PSM` trades with other stablecoins in 1:1 ratio, meaning 
 the value of the collateral is equal to received IST value. Since crypto assets can be very volatile, minting IST
 in a 1:1 ratio with another crypto asset would risk IST's value. Remember, IST is a fully-collateralized asset, so

--- a/lectureNine/lectureNine.md
+++ b/lectureNine/lectureNine.md
@@ -36,7 +36,6 @@ value of the collateral should be compared to the requested IST.
 
 `Economic Committee` is governance parameters that are crucial to Agoric Economy. These parameters include
 * Debt Limits
-* Supported Collateral Types
 * Interest Rates
 * Collateralization Ratio
 

--- a/lectureNine/lectureNine.md
+++ b/lectureNine/lectureNine.md
@@ -115,7 +115,7 @@ The relationship between `WalletFactory` and `SmartWallet` can be observed below
 
 ### PSM
 The Parity Stability Module(PSM) is similar to [The Peg Stability Module](https://mips.makerdao.com/mips/details/MIP29#sentence-summary)
-of MakerDAO. The basic idea is to mint IST against other stable coins in 1:1 ratio. `Economic Commitee` decides which 
+of MakerDAO. The basic idea is to mint IST against other stable coins in 1:1 ratio. BLD staker governance decides which 
 stablecoins are supported as collaterals. For a given instance of `PSM`, meaning a market that mints IST against a
 particular type of stablecoin, `Economic Commitee` also governs below parameters;
  


### PR DESCRIPTION
That choice is reserved to the BLD stakers.

I noticed this at around [10:30 in the recording](https://youtu.be/aLV43VU8eFM?t=634). I'm not sure how to submit a pull request for youtube videos, though :)
